### PR TITLE
Add python3-dev for Reticulate package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -y \
   libssh2-1-dev \
   jags \
   libv8-dev \
+  python3-dev \
   && apt-get -y autoclean
 
 # Libraries for display


### PR DESCRIPTION
Adding python3-dev to the image allows the reticulate library to work. Tested successfully with my target code on my dev VM.