### PR TITLE
feat: update default config with longer timeouts

### DIFF
--- a/4.0.4/Dockerfile
+++ b/4.0.4/Dockerfile
@@ -22,4 +22,5 @@ RUN apt-get update -y \
 # Libraries for display
 RUN R -e "install.packages(c('devtools', 'DT', 'leaflet', 'shinythemes', 'ggplot2', 'renv', 'packrat'), repos='http://cran.rstudio.com/')"
 
-
+# update the rshiny config with longer timeouts
+RUN sed -i 's/run_as shiny;/run_as shiny;\napp_init_timeout 1800;\napp_idle_timeout 300;/g' /opt/shiny-server/config/default.config


### PR DESCRIPTION
Simply used sed to update the config file with the new default timings.

I tested it first by exec'ing into an rshiny pod and running this command to check the effect on the config file.